### PR TITLE
exclude bin and obj from workspace scan ( defaults )

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Use `commentAnchors.workspace.excludeFiles` to define which files are excluded f
 
 ```
 {
-	"commentAnchors.workspace.excludeFiles": "**/{node_modules,.git,.idea,target,out,build,vendor}/**/*"
+	"commentAnchors.workspace.excludeFiles": "**/{node_modules,.git,.idea,target,out,build,bin,obj,vendor}/**/*"
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -187,7 +187,7 @@
 				},
 				"commentAnchors.workspace.excludeFiles": {
 					"type": "string",
-					"default": "**/{node_modules,.git,.idea,target,out,build,dist,vendor}/**/*",
+					"default": "**/{node_modules,.git,.idea,target,out,build,bin,obj,dist,vendor}/**/*",
 					"description": "The glob pattern of the files that will be excluded from matching by Comment Anchors",
 					"scope": "window"
 				},


### PR DESCRIPTION
This PR improves workspace scan speed especially when working with c# which produces bin and obj folder by excluding these two in the default settings "commentAnchors.workspace.excludeFiles".