### PR TITLE
feat: text decoration styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,7 @@ Use `commentAnchors.tags.anchors` to configure the anchor tags. Below is a list 
 - styleMode - *Customize what part of the comment is highlighted*
 - borderStyle - *Style to be applied to the tag border (See https://www.w3schools.com/cssref/pr_border.asp)*
 - borderRadius - *The curvature radius of the border (Requires borderStyle)*
+- textdecorationStyle - *Style to be applied to the tag text-decoration (See https://www.w3schools.com/cssref/pr_text_text-decoration.php)*
 - isBold - *Whether to apply bold formatting to the tag*
 - isItalic - *Whether to apply italicized formatting to the tag*
 - behavior - *Either "link" for link tags, "region" for region tags, or "anchor" for regular tags*

--- a/package.json
+++ b/package.json
@@ -392,6 +392,10 @@
 								"description": "The curvature radius of the applied border (Requires borderStyle to be set)",
 								"default": 0
 							},
+							"textdecorationStyle": {
+								"type": "string",
+								"description": "The style applied to the text-decoration, see https://www.w3schools.com/cssref/pr_text_text-decoration.php for more information"
+							},
 							"isBold": {
 								"type": "boolean",
 								"description": "Sets whether the tag is rendered in bold",

--- a/src/anchorEngine.ts
+++ b/src/anchorEngine.ts
@@ -352,7 +352,8 @@ export class AnchorEngine {
                         color: tag.highlightColor,
                         backgroundColor: tag.backgroundColor,
                         border: tag.borderStyle,
-                        borderRadius: tag.borderRadius ? tag.borderRadius + "px" : undefined
+                        borderRadius: tag.borderRadius ? tag.borderRadius + "px" : undefined,
+                        textDecoration: tag.textdecorationStyle,
                     };
 
                     // Optionally insert rulers
@@ -1203,6 +1204,7 @@ export interface TagEntry {
     styleMode?: 'tag' | 'comment' | 'full';
     borderStyle?: string;
     borderRadius?: number;
+    textdecorationStyle?: string;
     isBold?: boolean;
     isItalic?: boolean;
     scope?: string;

--- a/src/anchorListView.ts
+++ b/src/anchorListView.ts
@@ -40,6 +40,10 @@ export function createViewContent(engine: AnchorEngine, webview: Webview): strin
             tagStyle += "font-style: italic;";
         }
 
+		if (tag.textdecorationStyle) {
+			tagStyle += `text-decoration: ${tag.textdecorationStyle};`;
+		}
+
         if (tag.scope == "workspace") {
             tagFlags.push("Workspace Scope");
         } else {


### PR DESCRIPTION
Added feature from #215

Tag highlighting was missing the ability to do custom text decoration like line-through, underline, etc.
This PR exposes text decoration (the same way border styling is exposed) 